### PR TITLE
fix: export Collection and Document types

### DIFF
--- a/src/lapis/Collection.d.ts
+++ b/src/lapis/Collection.d.ts
@@ -2,15 +2,15 @@ import { CollectionOptions, CollectionSchema } from ".";
 import Document from "./Document";
 
 declare class Collection<T extends CollectionSchema> {
-    private dataStore: DataStore
-    private options: CollectionOptions<T> 
-    private openDocuments: { [index: string]: Promise<Document<T>> }
+    private dataStore: DataStore;
+    private options: CollectionOptions<T>;
+    private openDocuments: { [index: string]: Promise<Document<T>> };
 
     // as I'm using export =, I can only export one thing.
     // therefore, I'm importing CollectionOptions from index.d.ts where it is also referenced
-    constructor(name: string, options: CollectionOptions<T>)
+    constructor(name: string, options: CollectionOptions<T>);
 
-    load(key: string): Promise<Document<T>>
+    load(key: string): Promise<Document<T>>;
 }
 
 export = Collection;

--- a/src/lapis/Document.d.ts
+++ b/src/lapis/Document.d.ts
@@ -2,22 +2,22 @@ import { CollectionSchema } from ".";
 import Collection from "./Collection";
 
 declare class Document<T extends CollectionSchema> {
-    private collection: Collection<T>
-    private key: string
-    private validate: (data: T) => true | LuaTuple<[false, string]>
-    private lockId: string
-    private data: T
-    private closed: boolean
+    private collection: Collection<T>;
+    private key: string;
+    private validate: (data: T) => true | LuaTuple<[false, string]>;
+    private lockId: string;
+    private data: T;
+    private closed: boolean;
 
-    constructor(collection: Collection<T>, key: string, validate: (data: T) => true | LuaTuple<[false, string]>, lockId: string, data: T)
+    constructor(collection: Collection<T>, key: string, validate: (data: T) => true | LuaTuple<[false, string]>, lockId: string, data: T);
 
-    read(): T
+    read(): T;
 
-    write(data: T): void
+    write(data: T): void;
 
-    save(): Promise<void>
+    save(): Promise<void>;
 
-    close(): Promise<void>
+    close(): Promise<void>;
 }
 
 export = Document;

--- a/src/lapis/index.d.ts
+++ b/src/lapis/index.d.ts
@@ -1,5 +1,8 @@
 import { t } from "@rbxts/t";
 import Collection from "./Collection";
+import Document from "./Document";
+
+export { Collection, Document };
 
 // we do not want mixed tables
 export type CollectionSchema = Record<string, unknown>;

--- a/src/lapis/index.d.ts
+++ b/src/lapis/index.d.ts
@@ -2,7 +2,7 @@ import { t } from "@rbxts/t";
 import Collection from "./Collection";
 
 // we do not want mixed tables
-export type CollectionSchema = Record<string, unknown>
+export type CollectionSchema = Record<string, unknown>;
 
 interface LapisConfig {
     /** Max save/close retry attempts */
@@ -18,14 +18,14 @@ interface LapisConfig {
 	dataStoreService: Pick<DataStoreService, "GetDataStore" | "GetRequestBudgetForRequestType">;
 }
 
-export function setConfig(config: Partial<LapisConfig>): void
+export function setConfig(config: Partial<LapisConfig>): void;
 
 export interface CollectionOptions<T extends CollectionSchema> {
     /** Takes a document's data and returns true on success or false and an error on fail. */
-    validate: t.check<T>
-    defaultData: T
+    validate: t.check<T>;
+    defaultData: T;
     /** Migrations take old data and return new data. Order is first to last. */
-    migrations?: [...Array<(data: unknown) => unknown>, (data: unknown) => T]
+    migrations?: [...Array<(data: unknown) => unknown>, (data: unknown) => T];
 }
 
-export function createCollection<T extends CollectionSchema>(name: string, options: CollectionOptions<T>): Collection<T>
+export function createCollection<T extends CollectionSchema>(name: string, options: CollectionOptions<T>): Collection<T>;

--- a/src/lapis/index.d.ts
+++ b/src/lapis/index.d.ts
@@ -2,7 +2,7 @@ import { t } from "@rbxts/t";
 import Collection from "./Collection";
 import Document from "./Document";
 
-export { Collection, Document };
+export type { Collection, Document };
 
 // we do not want mixed tables
 export type CollectionSchema = Record<string, unknown>;


### PR DESCRIPTION
The types for `Collection` and `Document` should be exported by the package.

I also added some semicolons that were missing.