### PR TITLE
fix(types): use `any` instead of `unknown` in CollectionSchema

### DIFF
--- a/src/lapis/index.d.ts
+++ b/src/lapis/index.d.ts
@@ -5,7 +5,7 @@ import Document from "./Document";
 export type { Collection, Document };
 
 // we do not want mixed tables
-export type CollectionSchema = Record<string, unknown>;
+export type CollectionSchema = Record<string, any>;
 
 interface LapisConfig {
     /** Max save/close retry attempts */


### PR DESCRIPTION
This PR adds more support for player data defined with an interface instead of a type.

Normally, trying to do so results in a compiler error:

```ts
interface Data {
	value: string;
}

const collection = createCollection<Data>("data", {} as never);
//                                  ^^^^
// ⚠️ Index signature for type 'string' is missing in type 'Data'.
```

https://roblox-ts.com/playground/#code/JYWwDg9gTgLgBAbzgYygUwIYzQYQgG3zWRmAgDs4BfOAMyghDgCIABKAIwA8YBnAenwYwwXswDcAKEnBy2KLQzI0cACJYMiSQEgAbhnwBXNAC44vGFFkBzKVWnIKFlASIkylALwp0WXK+JSCgAedRgMAD4ACmYAEw1mABpEGgxeOHI0XTQoAEopIA

Changing `unknown` to `any` in the CollectionSchema type should fix this problem.